### PR TITLE
Fix typos and some whitespace

### DIFF
--- a/lattice2Base/Containers.py
+++ b/lattice2Base/Containers.py
@@ -174,7 +174,7 @@ def _getMetacontainerChildren(container, isrightcontainer_func):
 
 def isAContainer(obj):
     '''isAContainer(obj): returns True if obj is an object container, such as 
-    Group, Part, Body. The important characterisic of an object being a 
+    Group, Part, Body. The important characteristic of an object being a 
     container is that it can be activated to receive new objects. Documents 
     are considered containers, too.'''
     

--- a/lattice2BaseFeature.py
+++ b/lattice2BaseFeature.py
@@ -125,7 +125,7 @@ class LatticeFeature(object):
         # Auto-On an Auto-Off can be modified when recomputing. Force values are going to stay.
         
         prop = "ExposePlacement"
-        obj.addProperty("App::PropertyBool",prop,"Lattice","Makes the placement synchronized to Placement property. This will oftem make this object unmoveable. Not applicable to arrays.")
+        obj.addProperty("App::PropertyBool",prop,"Lattice","Makes the placement synchronized to Placement property. This will oftem make this object unmovable. Not applicable to arrays.")
 
         self.derivedInit(obj)
         
@@ -375,4 +375,3 @@ def splitSelection(sel):
         else:
             shapes.append(selobj)
     return (lattices, shapes)
-

--- a/lattice2BoundBox.py
+++ b/lattice2BoundBox.py
@@ -113,7 +113,7 @@ class _BoundBox:
         obj.CompoundTraversal = ["Use as a whole","Direct children only","Recursive"]
         obj.CompoundTraversal = "Use as a whole"
 
-        obj.addProperty("App::PropertyBool","Precision","BoundBox","Use precise alorithm (slower).")
+        obj.addProperty("App::PropertyBool","Precision","BoundBox","Use precise algorithm (slower).")
         obj.Precision = True
         
         obj.addProperty("App::PropertyEnumeration","OrientMode","BoundBox","Choose the orientation of bounding boxes to be made.")

--- a/lattice2PopulateChildren.py
+++ b/lattice2PopulateChildren.py
@@ -315,7 +315,7 @@ class _CommandLatticePopulateChildren_Move:
                 infoMessage("Move children",
                     "Moved Children command. Creates a compound from another compound, by moving its children.\n\n"+
                     "Each child is moved from one placement to another placement. Please select a compound, then a placement/array to move from, and  an array of placements to move to (order matters).\n"+
-                    "An array of placements can be used insead of a compound.")
+                    "An array of placements can be used instead of a compound.")
                 return
             cmdPopulate_shapes_FromTo()
         except Exception as err:
@@ -350,4 +350,3 @@ if FreeCAD.GuiUp:
 exportedCommands = ['Lattice2_PopulateChildrenGroupCommand']
 
 # -------------------------- /Gui command --------------------------------------------------
-

--- a/lattice2ValueSeriesGenerator.py
+++ b/lattice2ValueSeriesGenerator.py
@@ -1,7 +1,7 @@
 #***************************************************************************
 #*                                                                         *
 #*   Copyright (c) 2015 - Victor Titov (DeepSOIC)                          *
-#*                                               <vv.titov@gmail.com>      *  
+#*                                               <vv.titov@gmail.com>      *
 #*                                                                         *
 #*   This program is free software; you can redistribute it and/or modify  *
 #*   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -44,26 +44,26 @@ class ValueSeriesGenerator:
         self.gen_laws = ['Linear','Exponential']
         self.alignment_modes = ['Low', 'Center', 'High', 'Justify', 'Mirrored']
         self.readonlynessDict = {} # key = property name (string). Value = boolean (True == writable, non-readonly). Stores property read-only status requested by external code.
-        
-        
+
+
     def addProperties(self, groupname, groupname_gen, valuesdoc, valuestype = 'App::PropertyFloat'):
         #    _addProperty(proptype                  , propname        , defvalue, group, tooltip)
-        
-        # first, try to guess interface version. If we are re-adding properties to old feature, 
-        # it already has some other properties, but not Version. So we should default to 0 
-        # in this case. Therwise the Version property already exists, so default desn't matter; 
+
+        # first, try to guess interface version. If we are re-adding properties to old feature,
+        # it already has some other properties, but not Version. So we should default to 0
+        # in this case. Otherwise the Version property already exists, so default doesn't matter;
         # or we are creating a new generator, so default to 1.
         self._addProperty("App::PropertyInteger"    ,"VSGVersion"     , 0 if hasattr(self.documentObject, "Values") else 1 , groupname_gen, "Interface version")
         self.documentObject.setEditorMode("VSGVersion", 2) #hide this property
-        
+
         self._addProperty("App::PropertyStringList" ,"Values"         , None, groupname, valuesdoc)
         self._addProperty("App::PropertyEnumeration","ValuesSource"   , self.source_modes, groupname, "Select where to take the value series from.")
         self._addProperty("App::PropertyLink"       ,"SpreadsheetLink", None, groupname, "Link to spreadsheet to take values from.")
         self._addProperty("App::PropertyString"     ,"CellStart"      , 'A1', groupname, "Starting cell of first value (the rest are scanned downwards till an empty cell is encountered)")
-                                                                                                           
+
         self._addProperty("App::PropertyEnumeration","GeneratorMode"  , self.gen_modes, groupname_gen,"")
         self._addProperty("App::PropertyEnumeration","DistributionLaw", self.gen_laws, groupname_gen,"")
-                                                                                                           
+
         self._addProperty(valuestype                ,"SpanStart"      , 1.0, groupname_gen, "Starting value for value series generator")
         self._addProperty(valuestype                ,"SpanEnd"        , 7.0, groupname_gen, "Ending value for value series generator")
         self._addProperty("App::PropertyBool"       ,"EndInclusive"   , True, groupname_gen, "If True, the last value in series will equal SpanEnd. If False, the value equal to SpanEnd will be dropped.")
@@ -71,7 +71,7 @@ class ValueSeriesGenerator:
         self._addProperty("App::PropertyFloat"      ,"Step"           , 1.0, groupname_gen, "Step for value generator. For exponential law, it is a natural logarithm of change ratio.") # using float for Step, because step's unit depends n selected distribution law
         self._addProperty("App::PropertyFloat"      ,"Count"          , 7.0, groupname_gen, "Number of values to generate")
         self._addProperty("App::PropertyFloat"      ,"Offset"         , 0.0, groupname_gen, "Extra offset for the series, expressed as fraction of step.")
-            
+
     def _addProperty(self, proptype, propname, defvalue, group, tooltip):
         if hasattr(self.documentObject, propname):
             return
@@ -83,15 +83,15 @@ class ValueSeriesGenerator:
         obj = self.documentObject
         m = obj.GeneratorMode
         src = obj.ValuesSource
-        
+
         self._setPropertyWritable("Values"          , src == "Values Property"                    )
         self._setPropertyWritable("ValuesSource"    , True                                        )
         self._setPropertyWritable("SpreadsheetLink" , src == "Spreadsheet"                        )
         self._setPropertyWritable("CellStart"       , src == "Spreadsheet"                        )
-                                                                                                  
+
         self._setPropertyWritable("GeneratorMode"   , not self.isPropertyControlledByGenerator("GeneratorMode"  )  )
         self._setPropertyWritable("DistributionLaw" , not self.isPropertyControlledByGenerator("DistributionLaw")  )
-                                                                                             
+
         self._setPropertyWritable("SpanStart"       , not self.isPropertyControlledByGenerator("SpanStart"      )  )
         self._setPropertyWritable("SpanEnd"         , not self.isPropertyControlledByGenerator("SpanEnd"        )  )
         self._setPropertyWritable("EndInclusive"    , not self.isPropertyControlledByGenerator("EndInclusive"   )  )
@@ -99,19 +99,19 @@ class ValueSeriesGenerator:
         self._setPropertyWritable("Step"            , not self.isPropertyControlledByGenerator("Step"           )  )
         self._setPropertyWritable("Count"           , not self.isPropertyControlledByGenerator("Count"          )  )
         self._setPropertyWritable("Offset"          , not self.isPropertyControlledByGenerator("Offset"         )  )
-    
+
     def isPropertyControlledByGenerator(self, propname):
         obj = self.documentObject
         if not hasattr(obj, propname):
             raise AttributeError(obj.Name+": has no property named "+propname)
-        
+
         m = obj.GeneratorMode
 
         genOn = obj.ValuesSource == "Generator"
         if not genOn:
-            return False        
+            return False
 
-        if propname == "SpanStart": 
+        if propname == "SpanStart":
             return False
         elif propname == "SpanEnd":
             return False
@@ -123,21 +123,21 @@ class ValueSeriesGenerator:
             return False
 
     def setPropertyWritable(self, propname, bool_writable):
-        '''setPropertyWritable(self, propname, bool_writable): Use to force a property read-only 
-        (for example, when the property is driven by a link). If set to be writable, the read-onlyness 
+        '''setPropertyWritable(self, propname, bool_writable): Use to force a property read-only
+        (for example, when the property is driven by a link). If set to be writable, the read-onlyness
         will be set according to series generator logic.'''
         self.readonlynessDict[propname] = bool_writable
-        
+
     def _setPropertyWritable(self, propname, bool_writable, suppress_warning = False):
         if propname in self.readonlynessDict:
-            bool_writable = bool_writable and self.readonlynessDict[propname] 
+            bool_writable = bool_writable and self.readonlynessDict[propname]
         self.documentObject.setEditorMode(propname, 0 if bool_writable else 1)
-        
+
     def execute(self):
         obj = self.documentObject #shortcut
-        
+
         values = [] #list to be filled with values, that are giong to be written to obj.Values
-        
+
         if obj.ValuesSource == "Generator":
             #read out span and convert it to linear law
             if obj.DistributionLaw == 'Linear':
@@ -147,13 +147,13 @@ class ValueSeriesGenerator:
             elif obj.DistributionLaw == 'Exponential':
                 vSign = 1 if obj.SpanStart > 0.0 else -1.0
                 vStart = math.log(obj.SpanStart * vSign)
-                if obj.SpanEnd * vSign < ParaConfusion: 
+                if obj.SpanEnd * vSign < ParaConfusion:
                     raise ValueError(obj.Name+": Wrong SpanEnd value. It is either zero, or of different sign compared to SpanStart. In exponential distribution, it is not allowed.")
                 vEnd = math.log(obj.SpanEnd * vSign)
                 vStep = float(obj.Step)
             else:
                 raise ValueError(obj.Name+": distribution law not implemented: "+obj.DistributionLaw)
-                
+
             if obj.GeneratorMode == 'SpanN':
                 n = obj.Count
                 if obj.EndInclusive:
@@ -188,16 +188,16 @@ class ValueSeriesGenerator:
                 pass
             else:
                 raise ValueError(obj.Name+": Generator mode "+obj.GeneratorMode+" is not implemented")
-            
-            # Generate the actual array. We can use Step and N directly to 
+
+            # Generate the actual array. We can use Step and N directly to
             # completely avoid mode logic, since we had updated them
-            
+
             # cache properties into variables
             # vStart,vEnd are already in sync
             vStep = float(obj.Step)
             vOffset = float(obj.Offset)
             n = int(obj.Count)
-            
+
             # Generate the values
             if obj.GeneratorMode == 'Random':
                 import random
@@ -221,9 +221,9 @@ class ValueSeriesGenerator:
                         if n_tmp == 0:
                             n_tmp = 1 #justify failed!
                         vStep_justified = (vEnd - vStart)/n_tmp
-                        
+
                 list_evenDistrib = [vStart + vOffset*vStep + alignment_offset + vStep_justified*i for i in range(0, n)]
-                
+
                 #post-process alignment
                 if obj.Alignment == "Mirrored":
                     new_list = []
@@ -232,7 +232,7 @@ class ValueSeriesGenerator:
                         if abs(v) > 1e-12:
                             new_list.append(-v)
                     list_evenDistrib = new_list
-                
+
             if obj.DistributionLaw == 'Linear':
                 values = list_evenDistrib
             elif obj.DistributionLaw == 'Exponential':
@@ -250,7 +250,7 @@ class ValueSeriesGenerator:
                 col = addr[0:1]
                 row = addr[1:]
             row = int(row)
-            
+
             #loop until the value can't be read out
             values = []
             spsh = screen(obj.SpreadsheetLink)
@@ -264,8 +264,7 @@ class ValueSeriesGenerator:
             pass
         else:
             raise ValueError(obj.Name+": values source mode not implemented: "+obj.ValuesSource)
-        
+
         # finally. Fill in the values.
         if obj.ValuesSource != "Values Property":
             obj.Values = [str(v) for v in values]
-    


### PR DESCRIPTION
`codespell -q 3 -L ang,typ,vals,vertexes`