### PR TITLE
Edge annotations in sketcher and filter scripts

### DIFF
--- a/lattice2Downgrade.py
+++ b/lattice2Downgrade.py
@@ -22,10 +22,10 @@
 #***************************************************************************
 
 from lattice2Common import *
+from lattice2Utils import getAnnotatedShapes
 import lattice2Markers as markers
 import lattice2CompoundExplorer as LCE
 from lattice2BaseFeature import assureProperty #assureProperty(self, selfobj, proptype, propname, defvalue, group, tooltip)
-import re
 import logging
 
 import math
@@ -70,40 +70,47 @@ example = """
 # In the stack representations below, the topmost element is on the right.
 
 # <instruction> : <stack before> : <stack after> : description
-# QUOTE         : ...              : ... closure     : quotes the following instructions until "QUOTE END" for later use via CALL, PARTIAL or a higher-order function like MAP
-# END QUOTE                                      : ends quotation mode
-# CALL          : ... closure      : ...UpdatedStack : calls the closure and lets it manipulate the stack (no protection). The closure's saved stack is appended, so its instructions start executing with the stack "... saved"
-# PARTIAL       : ... arg closure  : ... closure'    : adds the arg on top of the saved stack of the closure
-# DEBUG         : ...              : ...             : prints the current stack
-# MAP           : ... list closure : ... list'       : calls the closure for each of the elements of the list. The closure's instructions are executed with the stack "... saved elt". After each call, the top of the stack is popped and stored in a list. This list is left as the top of the stack at the end
-# FILTER        : ... list closure : ... list'       : calls the closure for each of the elements of the list. The closure's instructions are executed with the stack "... saved elt". After each call, the top of the stack is popped and if it is true, the original element is added to a list. This list is left as the top of the stack at the end
-# STR some text : ...              : ... string      : pushes "some text" on the stack. The entire line is pushed after removing the first four characters "STR "
-# FLOAT 3.14    : ...              : ... float       : pushes 3.14 on the stack
-# INT 123       : ...              : ... int         : pushes 123 on the stack
-# BOOL True     : ...              : ... bool        : pushes True on the stack. Booleans are True or False
-# NOT           : ... bool         : ... bool        : pops the top of the stack which must be a boolean, and pushes back its negation
-# EQUAL         : ... t t          : ... bool        : pops two elements, pushes True if top == bot, False otherwise. Comparing elements of different types will always return False.
-# LT            : ... t t          : ... bool        : pops two elements, pushes True if top <  bot, False otherwise. Comparing elements of different types will always return False.
-# GT            : ... t t          : ... bool        : pops two elements, pushes True if top >  bot, False otherwise. Comparing elements of different types will always return False.
-# LE            : ... t t          : ... bool        : pops two elements, pushes True if top <= bot, False otherwise. Comparing elements of different types will always return False.
-# GE            : ... t t          : ... bool        : pops two elements, pushes True if top >= bot, False otherwise. Comparing elements of different types will always return False.
-# DROP          : ... t            : ...             : pops the top of the stack and discards it
-# DUP           : ... t            : ... t t         : pops the top of the stack, and pushes it back twice (duplication of the top of the stack)
-# SWAP          : ... t u          : ... u t         : pops two elements, and pushes them back in reverse order
-# PAIR          : ... t u          : ... pair        : pops two elements, and pushes a pair containing these two elements
-# UNPAIR        : ... pair         : ... t u         : pops a pair and pushes its two elements back onto the stack
-# NIL           : ...              : ... list        : pushes the empty list onto the stack
-# CONS          : ... list t       : ... list        : pops two elements, adds the top at the head of the bot, and pushes back the new list
-# UNCONS        : ... list         : ... list t      : pops the top of the stack which must be a list, and pushes back the tail of the list and its first element
-# NOP           : ...              : ...             : No operation (NOOP is also accepted)
-# SET xyz       : ... t            : ...             : pops the top of the stack, and saves it as a global variable named xyz
-# GET xyz       : ...              : ... t           : pushes the contents of the global variable xyz on top of the stack
-# .Annotation   : ... geometry     : ... string      : gets the annotation from the given geometry element. Annotations are stored as dummy de-activated Block constraints named __theannotation.123 (where 123 is the constraint's ID). A separate macro allows setting these annotations.
-# .attribute    : ... t            : ... u           : gets the attribute from the object on the top of the stack. Allowed attributes are {allowed_attributes}
+# QUOTE            : ...                 : ... closure     : quotes the following instructions until "QUOTE END" for later use via CALL, PARTIAL or a higher-order function like MAP
+# END QUOTE                                             : ends quotation mode
+# CALL             : ... closure         : ...UpdatedStack : calls the closure and lets it manipulate the stack (no protection). The closure's saved stack is appended, so its instructions start executing with the stack "... saved"
+# PARTIAL          : ... arg closure     : ... closure'    : adds the arg on top of the saved stack of the closure
+# DEBUG            : ...                 : ...             : prints the current stack
+# MAP              : ... list closure    : ... list'       : calls the closure for each of the elements of the list. The closure's instructions are executed with the stack "... saved elt". After each call, the top of the stack is popped and stored in a list. This list is left as the top of the stack at the end
+# FILTER           : ... list closure    : ... list'       : calls the closure for each of the elements of the list. The closure's instructions are executed with the stack "... saved elt". After each call, the top of the stack is popped and if it is true, the original element is added to a list. This list is left as the top of the stack at the end
+# STR some text    : ...                 : ... string      : pushes "some text" on the stack. The entire line is pushed after removing the first four characters "STR "
+# FLOAT 3.14       : ...                 : ... float       : pushes 3.14 on the stack
+# INT 123          : ...                 : ... int         : pushes 123 on the stack
+# BOOL True        : ...                 : ... bool        : pushes True on the stack. Booleans are True or False
+# NOT              : ... bool            : ... bool        : pops the top of the stack which must be a boolean, and pushes back its negation
+# EQUAL            : ... t t             : ... bool        : pops two elements, pushes True if top == bot, False otherwise. Comparing elements of different types will always return False.
+# LT               : ... t t             : ... bool        : pops two elements, pushes True if top <  bot, False otherwise. Comparing elements of different types will always return False.
+# GT               : ... t t             : ... bool        : pops two elements, pushes True if top >  bot, False otherwise. Comparing elements of different types will always return False.
+# LE               : ... t t             : ... bool        : pops two elements, pushes True if top <= bot, False otherwise. Comparing elements of different types will always return False.
+# GE               : ... t t             : ... bool        : pops two elements, pushes True if top >= bot, False otherwise. Comparing elements of different types will always return False.
+# AND              : ... bool bool       : ... bool        : pops two booleans, pushes (top and bot)
+# OR               : ... bool bool       : ... bool        : pops two booleans, pushes (top or bot)
+# XOR              : ... bool bool       : ... bool        : pops two booleans, pushes (top xor bot)
+# NAND             : ... bool bool       : ... bool        : pops two booleans, pushes (top nand bot)
+# NOR              : ... bool bool       : ... bool        : pops two booleans, pushes (top nor bot)
+# NXOR             : ... bool bool       : ... bool        : pops two booleans, pushes (top nxor bot)
+# DROP             : ... t               : ...             : pops the top of the stack and discards it
+# DUP              : ... t               : ... t t         : pops the top of the stack, and pushes it back twice (duplication of the top of the stack)
+# SWAP             : ... t u             : ... u t         : pops two elements, and pushes them back in reverse order
+# PAIR             : ... t u             : ... pair        : pops two elements, and pushes a pair containing these two elements
+# UNPAIR           : ... pair            : ... t u         : pops a pair and pushes its two elements back onto the stack
+# NIL              : ...                 : ... list        : pushes the empty list onto the stack
+# CONS             : ... list t          : ... list        : pops two elements, adds the top at the head of the bot, and pushes back the new list
+# UNCONS           : ... list            : ... list t      : pops the top of the stack which must be a list, and pushes back the tail of the list and its first element
+# NOP              : ...                 : ...             : No operation (NOOP is also accepted)
+# SET xyz          : ... t               : ...             : pops the top of the stack, and saves it as a global variable named xyz
+# GET xyz          : ...                 : ... t           : pushes the contents of the global variable xyz on top of the stack
+# .Annotations.xyz : ... annotated_shape : ... string      : gets the annotation from the given geometry element. Annotations are stored as dummy de-activated Block constraints named __theannotation.123 (where 123 is the constraint's ID) and some extra annotations are supplied by some Python objects (e.g. .Annotations.Geometry for sketches). A separate macro allows setting these annotations.
+# .attribute       : ... geometry        : ... u           : gets the attribute from the object on the top of the stack. Allowed attributes are {allowed_attributes}
 
 # The initial stack contains a list of sketch geometry elements.
 
 QUOTE
+  .Annotations.Geometry
   .Construction
   NOT
 END QUOTE
@@ -111,18 +118,18 @@ FILTER
 """
 example = example.format(allowed_attributes=",".join(sorted(["%s (%s)" % (k,v) for k,v in allowed_attributes.items()])))
 
-def interpret_map(stack, env, closure, lst, edge_annotations):
+def interpret_map(stack, env, closure, lst):
   result = []
   for elt in lst:
-     stack, env = interpret(stack + closure[1] + [elt], env, closure[0], edge_annotations)
+     stack, env = interpret(stack + closure[1] + [elt], env, closure[0])
      result.append(stack[-1])
      stack = stack[:-1]
   return (stack + [('list', result)], env)
 
-def interpret_filter(stack, env, closure, lst, edge_annotations):
+def interpret_filter(stack, env, closure, lst):
   result = []
   for elt in lst:
-     stack, env = interpret(stack + closure[1] + [elt], env, closure[0], edge_annotations)
+     stack, env = interpret(stack + closure[1] + [elt], env, closure[0])
      if stack[-1][0] != 'bool':
        raise ValueError("closure passed as an argument to filter should return a bool, but it returned a " + str(stack[-1][0]))
      if stack[-1][1] == True:
@@ -134,30 +141,44 @@ def interpret_filter(stack, env, closure, lst, edge_annotations):
      stack = stack[:-1]
   return (stack + [('list', result)], env)
 
-def interpret(stack, env, program, edge_annotations):
-  quoting = False
+boolOperations = {
+  'AND':  (lambda x, y: x and y),
+  'OR':   (lambda x, y: x or  y),
+  'XOR':  (lambda x, y: (x or y) and (not (x and y))),
+  'NAND': (lambda x, y: not (x and y)),
+  'NOR':  (lambda x, y: not (x or  y)),
+  'NXOR': (lambda x, y: (x and y) or (not (x or y)))
+}
+
+def interpret(stack, env, program):
+  quoting = 0
   for line in program:
     if line.strip() == '':
       pass # no-op
 
     # quotations
-    elif quoting and line == 'END QUOTE':
-      quoting = False
-    elif quoting and line == 'QUOTE':
-      raise ValueError("nested quotes are not allowed, use PARTIAL instead")
-    elif quoting:
+    elif quoting > 0:
       if stack[-1][0] != 'closure':
         raise ValueError("while in quote mode the top of the stack should be a closure")
-      stack[-1] = ('closure', (stack[-1][1][0] + [line], stack[-1][1][1]))
+      if line == 'END QUOTE':
+        quoting = quoting - 1
+      elif line == 'QUOTE':
+        quoting = quoting + 1
+
+      if quoting > 0: # if this wasn't the last 'END QUOTE', i.e. after decrementing we're still quoting, then add the instruction to the closure
+        stack[-1] = ('closure', (stack[-1][1][0] + [line], stack[-1][1][1]))
+      else:
+        pass
+
     elif line == 'QUOTE':
       stack.append(('closure', ([],[])))
-      quoting = True
+      quoting = 1
 
     # functions
     elif line == 'CALL':
       if stack[-1][0] != "closure":
         raise ValueError("CALL expected a closure")
-      stack, env = interpret(stack[:-1] + stack[-1][1][1], env, stack[-1][1][0], edge_annotations)
+      stack, env = interpret(stack[:-1] + stack[-1][1][1], env, stack[-1][1][0])
     elif line == 'PARTIAL':
       # push stack[-2] onto the closure's stack
       if stack[-1][0] != "closure":
@@ -169,14 +190,14 @@ def interpret(stack, env, program, edge_annotations):
       if stack[-2][0] != "list":
         raise ValueError("MAP expected a list as the second (deeper) element on the stack")
       closure = stack[-1][1]
-      stack, env = interpret_map(stack[:-2], env, stack[-1][1], stack[-2][1], edge_annotations)
+      stack, env = interpret_map(stack[:-2], env, stack[-1][1], stack[-2][1])
     elif line == 'FILTER':
       if stack[-1][0] != "closure":
         raise ValueError("FILTER expected a closure at the top of the stack")
       if stack[-2][0] != "list":
         raise ValueError("FILTER expected a list as the second (deeper) element on the stack")
       closure = stack[-1][1]
-      stack, env = interpret_filter(stack[:-2], env, stack[-1][1], stack[-2][1], edge_annotations)
+      stack, env = interpret_filter(stack[:-2], env, stack[-1][1], stack[-2][1])
 
     elif line == 'DEBUG':
       print('stack:')
@@ -207,6 +228,12 @@ def interpret(stack, env, program, edge_annotations):
       stack = stack[:-2] + [("bool", stack[-1] <= stack[-2])]
     elif line == 'GE':
       stack = stack[:-2] + [("bool", stack[-1] >= stack[-2])]
+    elif line in boolOperations:
+      if stack[-1][0] != "bool":
+        raise ValueError(line + " expected a boolean at the top of the stack")
+      if stack[-2][0] != "bool":
+        raise ValueError(line + " expected a boolean as the second (deeper) element on the stack")
+      stack = stack[:-2] + [("bool", boolOperations[line](stack[-1], stack[-2]))]
     elif line == 'DROP':
       stack = stack[:-1]
     elif line == 'DUP':
@@ -236,33 +263,32 @@ def interpret(stack, env, program, edge_annotations):
       stack = stack[:-1]
     elif line.startswith('GET '):
       stack.append(env[line[len('GET '):]])
-    elif line == '.Annotation':
-      if stack[-1][0] != "geometry":
-        raise ValueError(".Annotation expected a geometry elemnt")
-      stack = stack[:-1] + [('string', edge_annotations.get(stack[-1][1][0], None))]
+    elif line.startswith('.Annotations.'):
+      annotationName = line[len('.Annotations.'):]
+      if stack[-1][0] != "annotated_shape":
+        raise ValueError(".Annotations expected an annotated shape")
+      stack = stack[:-1] + [stack[-1][1][1].get(annotationName, ('none', None))]
     elif line in allowed_attributes.keys():
       if stack[-1][0] != "geometry":
         raise ValueError(line + " expected a geometry elemnt")
       stack = stack[:-1] + [(allowed_attributes[line], getattr(stack[-1][1][1], line[1:]))]
     else:
-      raise ValueError('Unknown operation: "' + line + '"' + repr(line) + ". " + str(line.strip() == '') + "; " + str(len(line)))
+      raise ValueError('Unknown operation: "' + line + '", repr=' + repr(line) + ". empty after strip=" + str(line.strip() == '') + ", len=" + str(len(line)))
   return stack, env
 
 def user_filter(filter, sketch):
   filter = [line.lstrip() for line in filter]
   filter = [line for line in filter if not line.startswith('#')]
-  constraint_re_matches = [(c,re.match(r"^__(.*)\.[0-9]+$", c.Name)) for c in sketch.Constraints]
-  edge_annotations = dict((c.First,match.group(1)) for c,match in constraint_re_matches if match)
-  stack = [('list', [('geometry', (i, g)) for i, g in enumerate(sketch.Geometry)])]
-  stack, env = interpret(stack, {}, filter, edge_annotations)
+  stack = [('list', [('annotated_shape', sh) for sh in getAnnotatedShapes(sketch)])]
+  stack, env = interpret(stack, {}, filter)
   if len(stack) != 1:
     raise ValueError("The stack should contain a single element after applying the filter's operations.")
   if stack[0][0] != 'list':
     raise ValueError("The stack should contain a list after applying the filter's operations.")
   for i, (type, g) in enumerate(stack[0][1]):
-    if type != 'geometry':
-      raise ValueError("The stack should contain a list of geometry elemnents after applying the filter's operations, wrong type for list element " + str(i) + " : " + str(type))
-  return [g for type,(id,g) in stack[0][1]]
+    if type != 'annotated_shape':
+      raise ValueError("The stack should contain a list of annotated shape elemnents after applying the filter's operations, wrong type for list element " + str(i) + " : " + str(type))
+  return [shape for type,(shape,annotations) in stack[0][1]]
 
 
 class _latticeDowngrade:
@@ -318,7 +344,6 @@ class _latticeDowngrade:
             rst = shp.Edges
         elif obj.Mode == 'SketchEdges':
             rst = user_filter(obj.Filter, obj.Base)
-            rst = [g.toShape() for g in rst]
         elif obj.Mode == 'Seam edges':
             rst = getAllSeams(shp)
         elif obj.Mode == 'Non-seam edges':

--- a/lattice2Downgrade.py
+++ b/lattice2Downgrade.py
@@ -24,6 +24,9 @@
 from lattice2Common import *
 import lattice2Markers as markers
 import lattice2CompoundExplorer as LCE
+from lattice2BaseFeature import assureProperty #assureProperty(self, selfobj, proptype, propname, defvalue, group, tooltip)
+import re
+import logging
 
 import math
 
@@ -55,12 +58,217 @@ def makeLatticeDowngrade(name):
         _ViewProviderLatticeDowngrade(obj.ViewObject)
     return obj
 
+allowed_attributes = {
+  '.StartPoint'   : 'vector',
+  '.EndPoint'     : 'vector',
+  '.Construction' : 'bool'
+}
+
+example = """
+# Write one instruction per line. Indentation is irrelevant but other whitespace is significant. Syntax is as follows:
+
+# In the stack representations below, the topmost element is on the right.
+
+# <instruction> : <stack before> : <stack after> : description
+# QUOTE         : ...              : ... closure     : quotes the following instructions until "QUOTE END" for later use via CALL, PARTIAL or a higher-order function like MAP
+# END QUOTE                                      : ends quotation mode
+# CALL          : ... closure      : ...UpdatedStack : calls the closure and lets it manipulate the stack (no protection). The closure's saved stack is appended, so its instructions start executing with the stack "... saved"
+# PARTIAL       : ... arg closure  : ... closure'    : adds the arg on top of the saved stack of the closure
+# DEBUG         : ...              : ...             : prints the current stack
+# MAP           : ... list closure : ... list'       : calls the closure for each of the elements of the list. The closure's instructions are executed with the stack "... saved elt". After each call, the top of the stack is popped and stored in a list. This list is left as the top of the stack at the end
+# FILTER        : ... list closure : ... list'       : calls the closure for each of the elements of the list. The closure's instructions are executed with the stack "... saved elt". After each call, the top of the stack is popped and if it is true, the original element is added to a list. This list is left as the top of the stack at the end
+# STR some text : ...              : ... string      : pushes "some text" on the stack. The entire line is pushed after removing the first four characters "STR "
+# FLOAT 3.14    : ...              : ... float       : pushes 3.14 on the stack
+# INT 123       : ...              : ... int         : pushes 123 on the stack
+# BOOL True     : ...              : ... bool        : pushes True on the stack. Booleans are True or False
+# NOT           : ... bool         : ... bool        : pops the top of the stack which must be a boolean, and pushes back its negation
+# EQUAL         : ... t t          : ... bool        : pops two elements, pushes True if top == bot, False otherwise. Comparing elements of different types will always return False.
+# LT            : ... t t          : ... bool        : pops two elements, pushes True if top <  bot, False otherwise. Comparing elements of different types will always return False.
+# GT            : ... t t          : ... bool        : pops two elements, pushes True if top >  bot, False otherwise. Comparing elements of different types will always return False.
+# LE            : ... t t          : ... bool        : pops two elements, pushes True if top <= bot, False otherwise. Comparing elements of different types will always return False.
+# GE            : ... t t          : ... bool        : pops two elements, pushes True if top >= bot, False otherwise. Comparing elements of different types will always return False.
+# DROP          : ... t            : ...             : pops the top of the stack and discards it
+# DUP           : ... t            : ... t t         : pops the top of the stack, and pushes it back twice (duplication of the top of the stack)
+# SWAP          : ... t u          : ... u t         : pops two elements, and pushes them back in reverse order
+# PAIR          : ... t u          : ... pair        : pops two elements, and pushes a pair containing these two elements
+# UNPAIR        : ... pair         : ... t u         : pops a pair and pushes its two elements back onto the stack
+# NIL           : ...              : ... list        : pushes the empty list onto the stack
+# CONS          : ... list t       : ... list        : pops two elements, adds the top at the head of the bot, and pushes back the new list
+# UNCONS        : ... list         : ... list t      : pops the top of the stack which must be a list, and pushes back the tail of the list and its first element
+# NOP           : ...              : ...             : No operation (NOOP is also accepted)
+# SET xyz       : ... t            : ...             : pops the top of the stack, and saves it as a global variable named xyz
+# GET xyz       : ...              : ... t           : pushes the contents of the global variable xyz on top of the stack
+# .Annotation   : ... geometry     : ... string      : gets the annotation from the given geometry element. Annotations are stored as dummy de-activated Block constraints named __theannotation.123 (where 123 is the constraint's ID). A separate macro allows setting these annotations.
+# .attribute    : ... t            : ... u           : gets the attribute from the object on the top of the stack. Allowed attributes are {allowed_attributes}
+
+# The initial stack contains a list of sketch geometry elements.
+
+QUOTE
+  .Construction
+  NOT
+END QUOTE
+FILTER
+"""
+example = example.format(allowed_attributes=",".join(sorted(["%s (%s)" % (k,v) for k,v in allowed_attributes.items()])))
+
+def interpret_map(stack, env, closure, lst, edge_annotations):
+  result = []
+  for elt in lst:
+     stack, env = interpret(stack + closure[1] + [elt], env, closure[0], edge_annotations)
+     result.append(stack[-1])
+     stack = stack[:-1]
+  return (stack + [('list', result)], env)
+
+def interpret_filter(stack, env, closure, lst, edge_annotations):
+  result = []
+  for elt in lst:
+     stack, env = interpret(stack + closure[1] + [elt], env, closure[0], edge_annotations)
+     if stack[-1][0] != 'bool':
+       raise ValueError("closure passed as an argument to filter should return a bool, but it returned a " + str(stack[-1][0]))
+     if stack[-1][1] == True:
+       result.append(elt)
+     elif stack[-1][1] == False:
+       pass
+     else:
+       raise ValueError("internal error: invalid boolean value: " + repr(stack[-1][1]))
+     stack = stack[:-1]
+  return (stack + [('list', result)], env)
+
+def interpret(stack, env, program, edge_annotations):
+  quoting = False
+  for line in program:
+    if line.strip() == '':
+      pass # no-op
+
+    # quotations
+    elif quoting and line == 'END QUOTE':
+      quoting = False
+    elif quoting and line == 'QUOTE':
+      raise ValueError("nested quotes are not allowed, use PARTIAL instead")
+    elif quoting:
+      if stack[-1][0] != 'closure':
+        raise ValueError("while in quote mode the top of the stack should be a closure")
+      stack[-1] = ('closure', (stack[-1][1][0] + [line], stack[-1][1][1]))
+    elif line == 'QUOTE':
+      stack.append(('closure', ([],[])))
+      quoting = True
+
+    # functions
+    elif line == 'CALL':
+      if stack[-1][0] != "closure":
+        raise ValueError("CALL expected a closure")
+      stack, env = interpret(stack[:-1] + stack[-1][1][1], env, stack[-1][1][0], edge_annotations)
+    elif line == 'PARTIAL':
+      # push stack[-2] onto the closure's stack
+      if stack[-1][0] != "closure":
+        raise ValueError("PARTIAL expected a closure")
+      stack = stack[:-2] + [('closure', (stack[-1][1][0], stack[-1][1][1] + [stack[-2]]))]
+    elif line == 'MAP':
+      if stack[-1][0] != "closure":
+        raise ValueError("MAP expected a closure at the top of the stack")
+      if stack[-2][0] != "list":
+        raise ValueError("MAP expected a list as the second (deeper) element on the stack")
+      closure = stack[-1][1]
+      stack, env = interpret_map(stack[:-2], env, stack[-1][1], stack[-2][1], edge_annotations)
+    elif line == 'FILTER':
+      if stack[-1][0] != "closure":
+        raise ValueError("FILTER expected a closure at the top of the stack")
+      if stack[-2][0] != "list":
+        raise ValueError("FILTER expected a list as the second (deeper) element on the stack")
+      closure = stack[-1][1]
+      stack, env = interpret_filter(stack[:-2], env, stack[-1][1], stack[-2][1], edge_annotations)
+
+    elif line == 'DEBUG':
+      print('stack:')
+      for i,x in enumerate(reversed(stack)):
+        print(str(i) + ": " + str(x))
+    elif line.startswith('STR '):
+      stack.append(("string", line[len('STR '):]))
+    elif line.startswith('FLOAT '):
+      stack.append(("float", float(line[len('FLOAT '):])))
+    elif line.startswith('INT '):
+      stack.append(("int", int(line[len('INT '):])))
+    elif line.startswith('BOOL '):
+      b = line[len('BOOL '):]
+      if b != "True" and b != "False":
+        raise ValueError("Invalid boolean literal, expected True or False")
+      stack.append(("bool", line[len('BOOL '):] == "True"))
+    elif line == 'NOT':
+      if stack[-1][0] != "bool":
+        raise ValueError("NOT expected a boolean at the top of the stack")
+      stack = stack[:-1] + [("bool", not stack[-1][1])]
+    elif line == 'EQUAL':
+      stack = stack[:-2] + [("bool", stack[-1] == stack[-2])]
+    elif line == 'LT':
+      stack = stack[:-2] + [("bool", stack[-1] < stack[-2])]
+    elif line == 'GT':
+      stack = stack[:-2] + [("bool", stack[-1] > stack[-2])]
+    elif line == 'LE':
+      stack = stack[:-2] + [("bool", stack[-1] <= stack[-2])]
+    elif line == 'GE':
+      stack = stack[:-2] + [("bool", stack[-1] >= stack[-2])]
+    elif line == 'DROP':
+      stack = stack[:-1]
+    elif line == 'DUP':
+      stack.append(stack[-1])
+    elif line == 'SWAP':
+      stack = stack[:-2] + [stack[-1], stack[-2]]
+    elif line == 'PAIR':
+      stack = stack[:-2] + [("pair", stack[-1], stack[-2])]
+    elif line == 'UNPAIR':
+      if stack[-1][0] != "pair":
+        raise ValueError("UNPAIR expected a pair")
+      stack = stack[:-1] + [stack[-1][1][0], stack[-1][1][1]]
+    elif line == 'NIL':
+      stack.append(('list', []))
+    elif line == 'CONS':
+      if stack[-2][0] != "list":
+        raise ValueError("CONS expected a list as the second (deeper) element on the stack")
+      stack = stack[:-2] + [('list', [stack[-1]] + stack[-2][1])]
+    elif line == 'UNCONS':
+      if stack[-1][0] != "list":
+        raise ValueError("UNCONS expected a list on the stack")
+      stack = stack[:-1] + [('list', stack[-1][1][1:]), stack[-1][1][0]]
+    elif line == 'NOP' or line == 'NOOP':
+      pass
+    elif line.startswith('SET '):
+      env[line[len('SET '):]] = stack[-1]
+      stack = stack[:-1]
+    elif line.startswith('GET '):
+      stack.append(env[line[len('GET '):]])
+    elif line == '.Annotation':
+      if stack[-1][0] != "geometry":
+        raise ValueError(".Annotation expected a geometry elemnt")
+      stack = stack[:-1] + [('string', edge_annotations.get(stack[-1][1][0], None))]
+    elif line in allowed_attributes.keys():
+      if stack[-1][0] != "geometry":
+        raise ValueError(line + " expected a geometry elemnt")
+      stack = stack[:-1] + [(allowed_attributes[line], getattr(stack[-1][1][1], line[1:]))]
+    else:
+      raise ValueError('Unknown operation: "' + line + '"' + repr(line) + ". " + str(line.strip() == '') + "; " + str(len(line)))
+  return stack, env
+
+def user_filter(filter, sketch):
+  filter = [line.lstrip() for line in filter]
+  filter = [line for line in filter if not line.startswith('#')]
+  constraint_re_matches = [(c,re.match(r"^__(.*)\.[0-9]+$", c.Name)) for c in sketch.Constraints]
+  edge_annotations = dict((c.First,match.group(1)) for c,match in constraint_re_matches if match)
+  stack = [('list', [('geometry', (i, g)) for i, g in enumerate(sketch.Geometry)])]
+  stack, env = interpret(stack, {}, filter, edge_annotations)
+  if len(stack) != 1:
+    raise ValueError("The stack should contain a single element after applying the filter's operations.")
+  if stack[0][0] != 'list':
+    raise ValueError("The stack should contain a list after applying the filter's operations.")
+  for i, (type, g) in enumerate(stack[0][1]):
+    if type != 'geometry':
+      raise ValueError("The stack should contain a list of geometry elemnents after applying the filter's operations, wrong type for list element " + str(i) + " : " + str(type))
+  return [g for type,(id,g) in stack[0][1]]
 
 
 class _latticeDowngrade:
     "The latticeDowngrade object"
     
-    _DowngradeModeList = ['Leaves','CompSolids','Solids','Shells','OpenWires','Faces','Wires','Edges','Seam edges','Non-seam edges','Vertices']
+    _DowngradeModeList = ['Leaves','CompSolids','Solids','Shells','OpenWires','Faces','Wires','Edges','SketchEdges','Seam edges','Non-seam edges','Vertices']
     
     def __init__(self,obj):
         self.Type = "latticeDowngrade"
@@ -69,9 +277,13 @@ class _latticeDowngrade:
         obj.addProperty("App::PropertyEnumeration","Mode","latticeDowngrade","Type of elements to output.")
         obj.Mode = ['bypass'] + self._DowngradeModeList
         obj.Mode = 'bypass'
-        
+
         obj.Proxy = self
-        
+
+        self.assureProperties(obj)
+
+    def assureProperties(self, selfobj):
+        assureProperty(selfobj, "App::PropertyStringList", "Filter", example.split('\n'), "latticeDowngrade", "Filter applied to the SubLink list")
 
     def execute(self,obj):
         rst = [] #variable to receive the final list of shapes
@@ -104,6 +316,9 @@ class _latticeDowngrade:
             rst = shp.Wires
         elif obj.Mode == 'Edges':
             rst = shp.Edges
+        elif obj.Mode == 'SketchEdges':
+            rst = user_filter(obj.Filter, obj.Base)
+            rst = [g.toShape() for g in rst]
         elif obj.Mode == 'Seam edges':
             rst = getAllSeams(shp)
         elif obj.Mode == 'Non-seam edges':


### PR DESCRIPTION
Hi :)

This MR is too much of a draft to be merged, and it is based on an ugly hack to annotated the edges of a sketch with custom information, but I thought you might find the use case and solution interesting. Lattice2 already provided most of the tools I needed, which saved me a lot of work, so thanks!

My use case for Lattice2 is to draw the net of a 3D object using the Sketcher, and then add slots and tabs to cut it out of paper (I use the Silhouette paper cutters), mark the folds (using an embossing tool or dull blade, also via the same CNC paper cutter) and assemble. Since these slots and tabs are very repetitive, I needed a way to automatically add tabs to specific edges, slots to other edges, and to extract the fold lines and cut lines into two separate shapes.

I tried using a SubLink to select the desired edges and a TopoSeries. This worked, but the selection of edges is very sensitive to changes in the sketch, just flipping an edge can completely change the order of the edges in the sketch's shape.

A hack to annotate edges in the sketcher was already in my drafts (it stores annotations inside the name of a dummy de-activated `block` constraint; unfortunately edges don't have names themselves nor any free-form field that could be repurposed, and their numbering changes all the time, so it's hard to keep track using a separate data structure; the sketcher correctly updates constraints and they do have a free-form name, so that's what I used).

This PR adds a new `SketchEdges` mode to the `Downgrade` tool, and an extra field containing a filtering script. The script is written in a silly but easy to implement stack-based language (just for this proof of concept, to avoid having to add a dependency on an interpreter for an existing script language). In retrospect, it would have been better to add this filtering mode to the `Compound Filter` tool, but I didn't know my way around Lattice2 yet when I started writing this a couple of days ago. Adding an embedded scripting language to the `Compound Filter` tool would be quite useful I think, regardless of the ability to annotate edges (which cannot be done without hacks of modifying FreeCAD's core, as far as I understand).

This PR also remembers the annotations present on the copies of the ObjectToTake of a TopoSeries, and makes these annotations available for filtering the result of the TopoSeries. My use case for this is to map a slot or tab on a set of edges, and extract the cut lines and fold lines of all copies of slots and tabs. Forwarding these annotations would be useful for all compounds, though I hope a cleaner solution will be available (native attributes of edges in FreeCAD) instead of having to manually copy this information.

Using a couple of helper [macros](https://github.com/DeepSOIC/Lattice2/files/5756139/macros.zip) which provide a simple UI to annotate edges and to automate the use of tools as described above, one can go from this
![before](https://user-images.githubusercontent.com/299872/103388975-058cd480-4b04-11eb-9e72-8258ba0487d3.png)
to this, in one step:
![after](https://user-images.githubusercontent.com/299872/103388977-07ef2e80-4b04-11eb-9a12-94b4980d2bf2.png)

This capability to filter edges by their annotation already allowed me to attach a TopoSeries to some edges, but also to attach one-off features to one or more edges, i.e. it can be used as a form of named external geometry which is robust to changes in the original sketch.

By adding a few more math utilities to the script language and by granting access to a few more safe properties, I hope to be able to chain features in a way which is robust to the topological naming problem, and to some more significant changes in the topology than one would get with simple names, e.g. select the topmost edge on the Y axis, edge furthest from another etc.

Here's the FreeCAD document shown in the screenshots (of course it requires using this branch to recompute): [pointy dodecahedron 003.FCStd.zip](https://github.com/DeepSOIC/Lattice2/files/5756144/pointy.dodecahedron.003.FCStd.zip)

:christmas_tree: :snowman_with_snow: 