### PR TITLE
Fix various typos

### DIFF
--- a/lattice2AttachablePlacement.py
+++ b/lattice2AttachablePlacement.py
@@ -123,7 +123,7 @@ class AttachedPlacementSubsequence(lattice2BaseFeature.LatticeFeature):
         
         obj.addProperty("App::PropertyLink", "Base", "Lattice Attached Placement Subsequence", "Link to Lattice Attached Placement, which is to be subsequenced.")
         obj.addProperty("App::PropertyString", "RefIndexFilter","Lattice Attached Placement Subsequence","Sets which references of attachment to cycle through children. '0000' = no cycle, '1000' = cycle only ref1. '' = cycle all if possible")
-        obj.addProperty("App::PropertyEnumeration", "CycleMode","Lattice Attached Placement Subsequence", "How to cycle through chidren. Open = advance each link till one reaches the end of array. Periodic = if array end reached, continue from begin if any children left.")
+        obj.addProperty("App::PropertyEnumeration", "CycleMode","Lattice Attached Placement Subsequence", "How to cycle through children. Open = advance each link till one reaches the end of array. Periodic = if array end reached, continue from begin if any children left.")
         obj.CycleMode = ['Open','Periodic']
         
     def derivedExecute(self,obj):

--- a/lattice2BaseFeature.py
+++ b/lattice2BaseFeature.py
@@ -88,7 +88,7 @@ def isObjectLattice(documentObject):
     
 def getMarkerSizeEstimate(ListOfPlacements, feature = None):
     '''getMarkerSizeEstimate(ListOfPlacements, feature = None): computes the default marker size for the array of placements.
-    If feauture is provided, marker size property will be assigned to viewer-based autosize if size based on array content is zero.'''
+    If feature is provided, marker size property will be assigned to viewer-based autosize if size based on array content is zero.'''
     if len(ListOfPlacements) == 0:
         return 1.0
     pathLength = 0

--- a/lattice2Placement.py
+++ b/lattice2Placement.py
@@ -48,7 +48,7 @@ class LatticePlacement(lattice2BaseFeature.LatticeFeature):
         obj.addProperty("App::PropertyEnumeration","PlacementChoice","Lattice Placement","Choose one of standard placements here.")
         obj.PlacementChoice = self._PlacementChoiceList
         
-        obj.addProperty("App::PropertyLength","Offset","Lattice Placement","Offset from oigin for XY/XZ/YZ plane modes")
+        obj.addProperty("App::PropertyLength","Offset","Lattice Placement","Offset from origin for XY/XZ/YZ plane modes")
         
         obj.addProperty("App::PropertyBool","FlipZ","Lattice Placement","Set to true to flip Z axis (also flips Y)")
         


### PR DESCRIPTION
Found via `codespell -q 3 -L ang,childs,typ,vals,vertexes`