### PR TITLE
Alpha implementation of lattice2 Roll Orient Mode

### DIFF
--- a/lattice2PolarArray2.py
+++ b/lattice2PolarArray2.py
@@ -71,7 +71,7 @@ class PolarArray(APlm.AttachableFeature):
         selfobj.UseArcRange = ['ignore', 'as Span', 'as Step']
         selfobj.addProperty('App::PropertyBool', 'UseArcRadius', "Polar Array", "If True, and attachment mode is concentric, supporting arc's radius is used as array radius.")
         selfobj.addProperty('App::PropertyEnumeration','OrientMode',"Polar Array","Orientation of placements. Zero - aligns with origin. Static - aligns with self placement.")
-        selfobj.OrientMode = ['Zero', 'Static', 'Radial', 'Vortex', 'Centrifuge', 'Launchpad', 'Dominoes']
+        selfobj.OrientMode = ['Zero', 'Static', 'Radial', 'Vortex', 'Centrifuge', 'Launchpad', 'Dominoes', 'Roll']
         selfobj.OrientMode = 'Radial'
         selfobj.addProperty('App::PropertyBool', 'Reverse', "Polar Array", "Reverses array direction.")
         selfobj.addProperty('App::PropertyBool', 'FlipX', "Polar Array", "Reverses x axis of every placement.")
@@ -158,7 +158,7 @@ class PolarArray(APlm.AttachableFeature):
                 V(        ),
                 V(-1, 0, 0)
             ))
-        elif selfobj.OrientMode == 'Launchpad':
+        elif selfobj.OrientMode == 'Launchpad' or selfobj.OrientMode == "Roll":
             baseplm = App.Placement(V(), App.Rotation(
                 V( 0, 0, 1), 
                 V(        ),
@@ -191,7 +191,13 @@ class PolarArray(APlm.AttachableFeature):
         output = [] # list of placements
         for ang in values:
             localrot = App.Rotation(App.Vector(0,0,1), ang * mm + angleplus)
-            localtransl = localrot.multVec(App.Vector(radius,0,0))
+            if selfobj.OrientMode == "Roll":
+                if on_arc:
+                    localtransl = localrot.multVec(App.Vector(radius, -radius*(ang - 90.0)*math.pi/180.0, 0))
+                else:
+                    localtransl = localrot.multVec(App.Vector(radius, -radius*ang*math.pi/180.0, 0))
+            else:
+                localtransl = localrot.multVec(App.Vector(radius,0,0))
             localplm = App.Placement(localtransl, localrot)
             resultplm = localplm.multiply(baseplm)
             if is_zero:


### PR DESCRIPTION
I wanted to be able to "wrap" a PartDesign object around a cylinder in order to do a boolean-cut to generate embossing rollers like this:

![embossing_rollers](https://github.com/DeepSOIC/Lattice2/assets/746949/36f73b09-ef9e-4961-980c-5dc44ae3be45)

This would also work for generating any arbitrary 3D meshing gear pattern. Although, it is fairly slow at high resolution.

I found the Lattice2 plugin's polar array was almost perfect for this operation, except that there wasn't a pre-existing Orient Mode that would allow the generator to do this "rolling" motion. So I added this mode myself. If you imagine the generator object as having a virtual contact surface on the circle that supports a polar pattern, this mode causes that contact surface to always maintain instantaneous rolling contact against that circle as it rotates around it.

![roll_lattice](https://github.com/DeepSOIC/Lattice2/assets/746949/e90601d1-907f-4c2c-abfc-f5ae979ec3a4)

To generate an embossing roller, create a polar array while setting the circle support to be the radius of the desired pitch circle. (I recommend a linear, Span/N distribution). Then populate the array with the generator object, fuse the array, and do a boolean cut against the roller object. Note that the boolean operations will take some time for large array sizes, so it might seem like FreeCAD has frozen for a while; give it time to work through it. You can use a small N for testing the geometry and then increase the resolution later.

I would call this 'alpha' as I haven't tested this mode extensively, only enough for my own use. Still, I thought it would be worth sharing, in case someone else finds it useful.