### PR TITLE
Use dumps/loads instead of getstate/setstate

### DIFF
--- a/CompoundFilter2.py
+++ b/CompoundFilter2.py
@@ -190,10 +190,10 @@ class _ViewProviderCompoundFilter:
         self.Object = vobj.Object
 
   
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/FuseCompound2.py
+++ b/FuseCompound2.py
@@ -76,10 +76,10 @@ class _ViewProviderFuseCompound:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/lattice2BaseFeature.py
+++ b/lattice2BaseFeature.py
@@ -247,10 +247,10 @@ class LatticeFeature(object):
                     #--DeepSOIC
                     pass 
                     
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
     
     def disableAttacher(self, selfobj, enable= False):
@@ -305,10 +305,10 @@ class ViewProviderLatticeFeature(object):
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
         
     def claimChildren(self):

--- a/lattice2BoundBox.py
+++ b/lattice2BoundBox.py
@@ -222,10 +222,10 @@ class _BoundBox:
         else:
             obj.Shape = Part.makeCompound(boxes_shapes)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
         
         
@@ -246,10 +246,10 @@ class _ViewProviderBoundBox:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 def CreateBoundBox(ShapeLink, 

--- a/lattice2Downgrade.py
+++ b/lattice2Downgrade.py
@@ -150,10 +150,10 @@ class _ViewProviderLatticeDowngrade:
         self.Object = vobj.Object
 
   
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/lattice2Mirror.py
+++ b/lattice2Mirror.py
@@ -219,10 +219,10 @@ class ViewProviderLatticeMirror(LBF.ViewProviderLatticeFeature):
         self.Object = vobj.Object
 
   
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/lattice2PDPattern.py
+++ b/lattice2PDPattern.py
@@ -271,10 +271,10 @@ class LatticePDPattern(object):
                     App.Console.PrintLog('{name} is unsupported, skipped.\n'.format(name= feature.Name))
         return baseshape
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 
@@ -292,10 +292,10 @@ class ViewProviderLatticePDPattern:
         self.Object = vobj.Object
 
   
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/lattice2RecomputeLocker.py
+++ b/lattice2RecomputeLocker.py
@@ -165,10 +165,10 @@ class ViewProviderLatticeRecomputeLocker:
     def unsetEdit(self,vobj,mode):
         return
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 # --------------------------------/document object------------------------------

--- a/lattice2ShapeInfoFeature.py
+++ b/lattice2ShapeInfoFeature.py
@@ -169,10 +169,10 @@ class ShapeInfoFeature:
             if type(attr) is list:
                 self.assignProp(selfobj,"App::PropertyInteger",propname+"Count",len(attr))
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 class ViewProviderShapeInfo:
@@ -195,10 +195,10 @@ class ViewProviderShapeInfo:
     def unsetEdit(self,vobj,mode):
         return
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/lattice2ShapeString.py
+++ b/lattice2ShapeString.py
@@ -225,10 +225,10 @@ class LatticeShapeString:
         obj.Shape = result
         
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
         
         
@@ -246,10 +246,10 @@ class ViewProviderLatticeShapeString:
         self.Object = vobj.Object
 
   
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 def CreateLatticeShapeString(name):

--- a/lattice2Slice.py
+++ b/lattice2Slice.py
@@ -113,10 +113,10 @@ class ViewProviderLatticeSlice:
         self.Object = vobj.Object
 
   
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/lattice2SubLink.py
+++ b/lattice2SubLink.py
@@ -143,10 +143,10 @@ class LatticeSubLink:
         # synchronize SubLink and Object+SubNames properties
         syncSublinkApart(selfobj, prop, 'SubLink', 'Object', 'SubNames')
     
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 class ViewProviderSubLink:
@@ -176,10 +176,10 @@ class ViewProviderSubLink:
         self.Object = vobj.Object
 
   
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/package.xml
+++ b/package.xml
@@ -2,10 +2,11 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Lattice2 Workbench</name>
   <description>Tools and arrays of all sorts and kinds, and local coordinate systems</description>
-  <version>1.0</version>
-  <date>2022-03-12</date>
+  <version>1.0.1</version>
+  <date>2024-02-25</date>
   <maintainer email="vv.titov@gmail.com">DeepSOIC</maintainer>
   <license file="LICENSE">LGPL-2.0-or-later</license>
+  <freecadmin>0.21.2</freecadmin>
   <url type="repository" branch="master">https://github.com/DeepSOIC/Lattice2</url>
   <url type="bugtracker">https://github.com/DeepSOIC/Lattice2/issues</url>
   <url type="documentation" branch="master">https://github.com/DeepSOIC/Lattice2/wiki</url>


### PR DESCRIPTION
I confirm that this fixes #80 in 0.21.2 for me. It however probably breaks for <= 0.21.1 so you might want to either keep both set/getstate and load/dumps, or mention this in docs. I have added `freecadmin` to the `package.xml` but I did not verify it really works.

Thanks