### PR TITLE
lattice2ShapeString: Fix ShapeString to allow more than one space

### DIFF
--- a/lattice2ShapeString.py
+++ b/lattice2ShapeString.py
@@ -226,7 +226,7 @@ class LatticeShapeString:
                 
                 shapes.append(shape.copy())
             else:
-                shapes.append(markers.getNullShapeShape())
+                shapes.append(markers.getNullShapeShape().copy())
         
         if len(shapes) == 0:
             scale = 1.0


### PR DESCRIPTION
The shape needed to include copies of the null marker, not the null marker itself.
Otherwise, the compound keeps only a single instance.