### PR TITLE
Fix logic error in strrev parsing

### DIFF
--- a/lattice2Compatibility.py
+++ b/lattice2Compatibility.py
@@ -15,7 +15,7 @@ def get_fc_version():
         rev = 0
     if '(GitTag)' in strrev:
         submi = int(strrev.split(" ")[0])
-    elif '(Git)' or '(Git shallow)' in strrev:
+    elif '(Git)' in strrev or '(Git shallow)' in strrev:
         try:
             rev = int(strrev.split(" ")[0])
         except Exception as err:


### PR DESCRIPTION
`'(Git)' or '(Git shallow)' in strrev` is always true because `'(Git)'` is a non-empty string.