### PR TITLE
Add base class for gui tests, update tests to check placements

### DIFF
--- a/test/gui/Lattice2GuiTestCase.py
+++ b/test/gui/Lattice2GuiTestCase.py
@@ -1,0 +1,46 @@
+import unittest
+import FreeCAD as App
+
+import lattice2BaseFeature
+
+
+class Lattice2GuiTestCase(unittest.TestCase):
+    """ Custom TestCase base class for lattice2 GUI tests in FreeCAD. """
+
+    def getPositionAlongVector(self, startPoint, directionVector, distance):
+        """ Calculate a position along a given direction vector from the lattice array's base point.
+
+        Args:
+            startPoint: The starting point (FreeCAD.Vector) of the translation.
+            directionVector: The direction vector (FreeCAD.Vector) to move along.
+            distance: The distance to move along the direction vector.
+
+        Returns:
+            FreeCAD.Vector representing the calculated position.
+        """
+        directionVector = App.Vector(directionVector)  # Make a copy to avoid modifying the original
+        unitDirection = directionVector.normalize()
+        offsetVector = unitDirection.multiply(distance)
+        return startPoint.add(offsetVector)
+
+    def checkPlacements(self, latticeArray, expectedPlacements, tolerance=0.001, identifier="array", sortFunc=None):
+        """ Test helper to compare generated placements against expected placements.
+            Number of placements and individual placement values are compared.
+
+        Args:
+            latticeArray: The Lattice2 array object to get placements from.
+            expectedPlacements: A list of expected placement objects to compare against.
+            tolerance: The tolerance for placement comparison. Defaults to 0.1.
+            identifier: An optional identifier string for error messages. Defaults to "array".
+            sortFunc: Optional function to sort placements before comparison.
+        """
+        actualPlacements = lattice2BaseFeature.getPlacementsList(latticeArray)
+        if sortFunc:
+            actualPlacements.sort(key=sortFunc)
+            expectedPlacements.sort(key=sortFunc)
+        self.assertEqual(len(expectedPlacements), len(actualPlacements),
+                         f"Unexpected number of placements generated.\nExpected: {len(expectedPlacements)}\nActual: {len(actualPlacements)}")
+        for i, placement in enumerate(actualPlacements):
+            expectedPlacement = expectedPlacements[i]
+            self.assertTrue(placement.isSame(expectedPlacement, tolerance),
+                            f"Placement mismatch at index {i} for {identifier}.\nExpected: {expectedPlacement}\nActual: {placement}")

--- a/test/gui/TestLatticePlacement.py
+++ b/test/gui/TestLatticePlacement.py
@@ -4,9 +4,10 @@ import FreeCAD as App
 
 import lattice2ArrayFromShape
 import lattice2Placement
+from test.gui.Lattice2GuiTestCase import Lattice2GuiTestCase
 
 
-class TestLatticePlacement(unittest.TestCase):
+class TestLatticePlacement(Lattice2GuiTestCase):
     """ Unit tests for single lattice placement objects in FreeCAD. """
 
     def setUp(self):
@@ -42,9 +43,7 @@ class TestLatticePlacement(unittest.TestCase):
             self._test_common(placement, placementName, placementChoice)
             self.assertEqual(placementChoice, placement.PlacementChoice,
                              msg=f"PlacementChoice mismatch for {placementName}")
-            self.assertTrue(
-                placement.Placement.Rotation.isSame(rotation, 0.1),  # Allow small tolerance for rounding errors
-                msg=f"Placement rotation mismatch for {placementName}")
+            self.checkPlacements(placement, [App.Placement(App.Vector(), rotation)])
 
     def test_single_lattice_placement_along_axis(self):
         """ Test basic creation and rotation of single lattice placement objects along specific axes.
@@ -73,8 +72,7 @@ class TestLatticePlacement(unittest.TestCase):
 
             self._test_common(placement, placementName, alongAxis)
             self.assertEqual(rotationTuple[0], placement.XDir_actual, msg=f"XDir_actual mismatch for {placementName}")
-            self.assertTrue(placement.Placement.Rotation.isSame(rotationTuple[1], 0.1),
-                            msg=f"Placement rotation mismatch for {placementName}")
+            self.checkPlacements(placement, [App.Placement(App.Vector(), rotationTuple[1])])
 
     def test_single_lattice_placement_euler_angles(self):
         """ Test basic creation and rotation of single lattice placement objects using Euler angles."""
@@ -100,8 +98,10 @@ class TestLatticePlacement(unittest.TestCase):
             placement = self.doc.getObject(placementName)
 
             self._test_common(placement, placementName, f"Euler_{'_'.join(angleNames)}")
-            self.assertTrue(placement.Placement.Rotation.isSame(App.Rotation(*testRotation), 0.1),
-                            msg=f"Placement rotation mismatch for {placementName}")
+
+            self.checkPlacements(placement, [App.Placement(App.Vector(), App.Rotation(testRotation[0], testRotation[1],
+                                                                                      testRotation[2]))],
+                                 identifier=placementName)
 
     def test_lattice_placement_from_shape(self):
         """ Test creation and of single lattice placement objects from shape geometry.
@@ -132,5 +132,4 @@ class TestLatticePlacement(unittest.TestCase):
             placement = self.doc.getObject(placementName)
 
             self._test_common(placement, placementName, translateMode)
-            self.assertEqual(expectedPosition, placement.Placement.Base,
-                             msg=f"Placement base position mismatch for {placementName}")
+            self.checkPlacements(placement, [App.Placement(expectedPosition, App.Rotation())], identifier=placementName)


### PR DESCRIPTION
This PR adds a base class for Lattice2 Gui test cases to provide convenience functions.  It adds the checkPlacements method, which will check the actual placements against a list of expected placements (position and rotation). Checks for Values and Start/End points are omitted, as these should be covered by the final positions of the placements. 

I am worried this is a bit convoluted, but I wanted a good way to abstract these assertions since they'll see use in most tests. 